### PR TITLE
Doc & test for Openapi request response serializers

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -375,6 +375,20 @@ operationIds.
 In order to work around this, you can override `get_operation_id_base()` to
 provide a different base for name part of the ID.
 
+#### `get_serializer()`
+
+If the view has implemented `get_serializer()`, returns the result.
+
+#### `get_request_serializer()`
+
+By default returns `get_serializer()` but can be overridden to
+differentiate between request and response objects.
+
+#### `get_response_serializer()`
+
+By default returns `get_serializer()` but can be overridden to
+differentiate between request and response objects.
+
 ### `AutoSchema.__init__()` kwargs
 
 `AutoSchema` provides a number of `__init__()` kwargs that can be used for

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -702,6 +702,90 @@ class TestOperationIntrospection(TestCase):
         operationId = inspector.get_operation_id(path, method)
         assert operationId == 'listItem'
 
+    def test_different_request_response_objects(self):
+        class RequestSerializer(serializers.Serializer):
+            text = serializers.CharField()
+
+        class ResponseSerializer(serializers.Serializer):
+            text = serializers.BooleanField()
+
+        class CustomSchema(AutoSchema):
+            def get_request_serializer(self, path, method):
+                return RequestSerializer()
+
+            def get_response_serializer(self, path, method):
+                return ResponseSerializer()
+
+        path = '/'
+        method = 'POST'
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = CustomSchema()
+        inspector.view = view
+
+        components = inspector.get_components(path, method)
+        assert components == {
+            'Request': {
+                'properties': {
+                    'text': {
+                        'type': 'string'
+                    }
+                },
+             'required': ['text'],
+             'type': 'object'
+            },
+            'Response': {
+                'properties': {
+                    'text': {
+                        'type': 'boolean'}
+                    },
+              'required': ['text'],
+              'type': 'object'
+            }
+        }
+
+        operation = inspector.get_operation(path, method)
+        assert operation == {
+            'operationId': 'createExample',
+            'description': '',
+            'parameters': [],
+            'requestBody': {
+                'content': {
+                    'application/json': {
+                        'schema': {
+                            '$ref': '#/components/schemas/Request'
+                        }
+                    },
+                    'application/x-www-form-urlencoded': {
+                        'schema': {
+                            '$ref': '#/components/schemas/Request'
+                        }
+                    },
+                    'multipart/form-data': {
+                        'schema': {
+                            '$ref': '#/components/schemas/Request'
+                        }
+                    }
+                }
+            },
+            'responses': {
+                '201': {
+                    'content': {
+                        'application/json': {
+                            'schema': {
+                                '$ref': '#/components/schemas/Response'
+                            }
+                        }
+                    },
+                    'description': ''
+                }
+            },
+            'tags': ['']
+        }
+
     def test_repeat_operation_ids(self):
         router = routers.SimpleRouter()
         router.register('account', views.ExampleGenericViewSet, basename="account")


### PR DESCRIPTION
Add brief documentation of the new functions and add a test case confirming the different request vs response body generation works.